### PR TITLE
Monk: Add Monk Kit on master branch

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO doit
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,55 @@
+namespace: doit
+
+database:
+  defines: runnable
+  inherits: mariadb/mariadb
+  metadata:
+    name: database
+    description: External database service required by the backend.
+    icon: https://www.vectorlogo.zone/logos/mariadb/mariadb-ar21.png
+  variables:
+    mariadb-database-name:
+      type: string
+      value: mariadb
+      description: ''
+    mariadb-image:
+      type: string
+      value: $mariadb-image-tag default("10.10")
+      description: ''
+    mariadb-image-tag:
+      type: string
+      value: latest
+      description: ''
+    mariadb-root-password:
+      type: string
+      value: 4wfoA7auxY
+      description: ''
+    mariadb-user-name:
+      type: string
+      value: mariadbuser
+      description: ''
+    mariadb-user-password:
+      type: string
+      value: Cz9mGzmRtW
+      description: ''
+    mysql-database:
+      type: string
+      value: $mariadb-database-name default("mariadb")
+      description: ''
+    mysql-password:
+      type: string
+      value: $mariadb-user-password default("Cz9mGzmRtW")
+      description: ''
+    mysql-root-password:
+      type: string
+      value: $mariadb-root-password default("4wfoA7auxY")
+      description: ''
+    mysql-user:
+      type: string
+      value: $mariadb-user-name default("mariadbuser")
+      description: ''
+
+stack:
+  defines: group
+  members:
+    - doit/database


### PR DESCRIPTION
# PR Description: Containerization and Deployment Configuration

## Overview
This PR introduces containerization and deployment configuration for a todo-list application with a Vue.js frontend and a Go backend. The backend is responsible for serving the frontend as static files and providing API endpoints. Additionally, the application requires an external database service, which is inferred from the environment variables set in the Dockerfile.

## Changes

### Service Mapping
- The backend Go application uses the `github.com/gin-contrib/static` package to serve static files, indicating that the frontend is served by the backend service and does not require a separate service in production.
- Environment variables in the Dockerfile (`DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, and `DB_NAME`) suggest that the backend service connects to a database. However, the exact type of database used is not explicitly defined in the Go files.
- An external database service is required, and based on the environment variables, it has been inferred to be a MariaDB database.

### Database Service
- A suitable database kit was found on MonkHub, which will be used to deploy the MariaDB service for the application.

### Dockerfile for Backend
- The Dockerfile build process encountered an error during the 'yarn install' step. Despite successful installation of Python and other dependencies, the build failed without a clear error message.
- The issue may be related to one of the Node.js packages being built, the 'yarn install' command itself, or an environment-specific problem within the Docker build process.
- It is recommended to attempt to build the frontend outside of Docker to see if the issue is reproducible and to enable verbose logging for 'yarn install' to gather more information about the failure.

### Service Composition
- The configuration for the 'database' service has been received, exposing a 'mariadb' port with several variables set, such as 'mariadb-database-name', 'mariadb-image', 'mariadb-root-password', etc.
- No connections are set for this service, and no further service configurations have been provided to continue the analysis.

## Configuration Files
- `monk.yaml`: Allows deployment of the application to monk.io.
- `MANIFEST`: Lists monk.io YAML files that should be deployed to monk.io.

## Next Steps
- Resolve the Dockerfile build issue for the frontend by building outside of Docker and enabling verbose logging for 'yarn install'.
- Obtain additional service configurations to analyze how they should connect to the 'database' service and to set any missing variables.

## Conclusion
This PR sets the groundwork for deploying the todo-list application using Monk.io. Further investigation and configuration are required to ensure a smooth deployment process.